### PR TITLE
(client) fix problem in output process

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -147,12 +147,12 @@ def read_stdout_process(proc, id_job, str_thread_id, command):
     realtime_output = ""
 
     while True:
-        realtime_output += proc.stdout.readline()
+        realtime_output += proc.stdout.readline().replace("\x00", "")
 
         if proc.poll() is not None:
             # entre temps, des nouveaux messages sont peut-etre arrives
             for line in proc.stdout.readlines():
-                realtime_output += line
+                realtime_output += line.replace("\x00", "")
 
             if realtime_output:
                 url_tmp = "job/" + str(id_job) + "/appendLog"


### PR DESCRIPTION
Petit patch qui permet de faire passer un log d'un traitement pour l'ocsge.
Dans le log, il y avait le caractère \x00 qui posait problème. 

Ce patch n'est pas entièrement satisfaisant car il ne permet de garantir le bon fonctionnement du client lorsqu'il sera confronter à d'autres caractères spéciaux.
 
Cette MR est attente de validation de la part de l'équipe OCSGE avant son intégration dans master.